### PR TITLE
feat (EBD-6): s3 Transform 작업 순서 변경

### DIFF
--- a/read_parquet.ipynb
+++ b/read_parquet.ipynb
@@ -53,29 +53,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "par_df = spark.read.parquet(\"C:/Users/aryij/Downloads/191001\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+----------------------+-------------+-------------+-------------+-------+------+---------+------------------------------------+\n",
-      "|category_id        |event_time         |event_time_ymd|event_time_hms|event_time_month|event_time_day|event_time_hour|event_time_day_name|event_type|product_id|category_code         |category_lv_1|category_lv_2|category_lv_3|brand  |price |user_id  |user_session                        |\n",
-      "+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+----------------------+-------------+-------------+-------------+-------+------+---------+------------------------------------+\n",
-      "|2053013555631882655|2019-10-02 23:26:48|2019-10-02    |23:26:48      |10              |02            |14             |Wed                |view      |1005008   |electronics.smartphone|electronics  |smartphone   |None         |xiaomi |99.75 |542457608|9a9fdd60-02a6-4b83-a1cc-0d07df1be21e|\n",
-      "|2053013555631882655|2019-10-02 23:26:49|2019-10-02    |23:26:49      |10              |02            |14             |Wed                |view      |1005153   |electronics.smartphone|electronics  |smartphone   |None         |xiaomi |231.64|512448158|dbe3f212-d20b-4383-a1b7-68335fb19a4e|\n",
-      "|2053013555631882655|2019-10-02 23:26:49|2019-10-02    |23:26:49      |10              |02            |14             |Wed                |view      |1004858   |electronics.smartphone|electronics  |smartphone   |None         |samsung|132.56|554643162|bda38f5c-70ac-4756-9b94-fae58c615cc5|\n",
-      "+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+----------------------+-------------+-------------+-------------+-------+------+---------+------------------------------------+\n",
+      "Current TimeZone: UTC\n"
+     ]
+    }
+   ],
+   "source": [
+    "spark.conf.set(\"spark.sql.session.timeZone\", \"UTC\")\n",
+    "print(\"Current TimeZone:\", spark.conf.get(\"spark.sql.session.timeZone\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "par_df = spark.read.parquet(\"C:/Users/aryij/Downloads/191001\")\n",
+    "par_08_df = spark.read.parquet(\"C:/Users/aryij/Downloads/191008\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+------------------------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+---------------------------+-------------+-------------+-------------+-----------+-----+\n",
+      "|user_id  |user_session                        |category_id        |event_time         |event_time_ymd|event_time_hms|event_time_month|event_time_day|event_time_hour|event_time_day_name|event_type|product_id|category_code              |category_lv_1|category_lv_2|category_lv_3|brand      |price|\n",
+      "+---------+------------------------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+---------------------------+-------------+-------------+-------------+-----------+-----+\n",
+      "|516348315|6e2193d0-fcb5-44fb-8713-fe9f1c618a16|2053013561847841545|2019-10-02 14:26:48|2019-10-02    |14:26:48      |10              |02            |14             |Wed                |view      |23700090  |furniture.bedroom.blanket  |furniture    |bedroom      |blanket      |arua       |61.01|\n",
+      "|542457608|9a9fdd60-02a6-4b83-a1cc-0d07df1be21e|2053013555631882655|2019-10-02 14:26:48|2019-10-02    |14:26:48      |10              |02            |14             |Wed                |view      |1005008   |electronics.smartphone     |electronics  |smartphone   |none         |xiaomi     |99.75|\n",
+      "|513077305|59f64eb8-57ad-417e-aca8-d0169dde1912|2053013554658804075|2019-10-02 14:26:49|2019-10-02    |14:26:49      |10              |02            |14             |Wed                |view      |4801033   |electronics.audio.headphone|electronics  |audio        |headphone    |plantronics|12.69|\n",
+      "+---------+------------------------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+---------------------------+-------------+-------------+-------------+-----------+-----+\n",
       "only showing top 3 rows\n",
       "\n"
      ]
@@ -87,7 +106,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+--------+-------+\n",
+      "|  user_id|        user_session|        category_id|         event_time|event_time_ymd|event_time_hms|event_time_month|event_time_day|event_time_hour|event_time_day_name|event_type|product_id|       category_code|category_lv_1|category_lv_2|category_lv_3|   brand|  price|\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+--------+-------+\n",
+      "|541312140|72d76fde-8bb3-4e0...|2103807459595387724|2019-10-01 00:00:00|    2019-10-01|      00:00:00|              10|            01|             00|                Tue|      view|  44600062|             unknown|      unknown|         none|         none|shiseido|  35.79|\n",
+      "|554748717|9333dfbd-b87a-470...|2053013552326770905|2019-10-01 00:00:00|    2019-10-01|      00:00:00|              10|            01|             00|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater|    aqua|   33.2|\n",
+      "|519107250|566511c2-e2e3-422...|2053013559792632471|2019-10-01 00:00:01|    2019-10-01|      00:00:01|              10|            01|             00|                Tue|      view|  17200506|furniture.living_...|    furniture|  living_room|         sofa|    rals|  543.1|\n",
+      "|550050854|7c90fc70-0e80-459...|2053013558920217191|2019-10-01 00:00:01|    2019-10-01|      00:00:01|              10|            01|             00|                Tue|      view|   1307067|  computers.notebook|    computers|     notebook|         none|  lenovo| 251.74|\n",
+      "|535871217|c6bd7419-2748-4c5...|2053013555631882655|2019-10-01 00:00:04|    2019-10-01|      00:00:04|              10|            01|             00|                Tue|      view|   1004237|electronics.smart...|  electronics|   smartphone|         none|   apple|1081.98|\n",
+      "|512742880|0d0d91c2-c9c2-4e8...|2053013561092866779|2019-10-01 00:00:05|    2019-10-01|      00:00:05|              10|            01|             00|                Tue|      view|   1480613|   computers.desktop|    computers|      desktop|         none|  pulser| 908.62|\n",
+      "|555447699|4fe811e9-91de-46d...|2053013553853497655|2019-10-01 00:00:08|    2019-10-01|      00:00:08|              10|            01|             00|                Tue|      view|  17300353|             unknown|      unknown|         none|         none|   creed| 380.96|\n",
+      "|550978835|6280d577-25c8-414...|2053013558031024687|2019-10-01 00:00:08|    2019-10-01|      00:00:08|              10|            01|             00|                Tue|      view|  31500053|             unknown|      unknown|         none|         none|luminarc|  41.16|\n",
+      "|520571932|ac1cd4e5-a3ce-422...|2053013565480109009|2019-10-01 00:00:10|    2019-10-01|      00:00:10|              10|            01|             00|                Tue|      view|  28719074|  apparel.shoes.keds|      apparel|        shoes|         keds|   baden| 102.71|\n",
+      "|537918940|406c46ed-90a4-478...|2053013555631882655|2019-10-01 00:00:11|    2019-10-01|      00:00:11|              10|            01|             00|                Tue|      view|   1004545|electronics.smart...|  electronics|   smartphone|         none|  huawei| 566.01|\n",
+      "|555158050|b5bdd0b3-4ca2-4c5...|2053013554776244595|2019-10-01 00:00:11|    2019-10-01|      00:00:11|              10|            01|             00|                Tue|      view|   2900536|appliances.kitche...|   appliances|      kitchen|    microwave|elenberg|  51.46|\n",
+      "|530282093|50a293fb-5940-41b...|2053013555631882655|2019-10-01 00:00:11|    2019-10-01|      00:00:11|              10|            01|             00|                Tue|      view|   1005011|electronics.smart...|  electronics|   smartphone|         none| samsung| 900.64|\n",
+      "|555444559|98b88fa0-d8fa-4b9...|2053013552326770905|2019-10-01 00:00:13|    2019-10-01|      00:00:13|              10|            01|             00|                Tue|      view|   3900746|appliances.enviro...|   appliances|  environment| water_heater|   haier| 102.38|\n",
+      "|541312140|72d76fde-8bb3-4e0...|2103807459595387724|2019-10-01 00:00:15|    2019-10-01|      00:00:15|              10|            01|             00|                Tue|      view|  44600062|             unknown|      unknown|         none|         none|shiseido|  35.79|\n",
+      "|555446365|7f0062d8-ead0-4e0...|2053013557099889147|2019-10-01 00:00:16|    2019-10-01|      00:00:16|              10|            01|             00|                Tue|      view|  13500240|furniture.bedroom...|    furniture|      bedroom|          bed|     brw|  93.18|\n",
+      "|513642368|17566c27-0a8f-450...|2053013561638126333|2019-10-01 00:00:17|    2019-10-01|      00:00:17|              10|            01|             00|                Tue|      view|  23100006|             unknown|      unknown|         none|         none| unknown| 357.79|\n",
+      "|537192226|e3151795-c355-4ef...|2053013554415534427|2019-10-01 00:00:18|    2019-10-01|      00:00:18|              10|            01|             00|                Tue|      view|   1801995|electronics.video.tv|  electronics|        video|           tv|   haier| 193.03|\n",
+      "|519528062|901b9e3c-3f8f-414...|2053013555069845885|2019-10-01 00:00:18|    2019-10-01|      00:00:18|              10|            01|             00|                Tue|      view|  10900029|appliances.kitche...|   appliances|      kitchen|        mixer|   bosch|  58.95|\n",
+      "|550050854|7c90fc70-0e80-459...|2053013558920217191|2019-10-01 00:00:19|    2019-10-01|      00:00:19|              10|            01|             00|                Tue|      view|   1306631|  computers.notebook|    computers|     notebook|         none|      hp| 580.89|\n",
+      "|535871217|c6bd7419-2748-4c5...|2053013555631882655|2019-10-01 00:00:19|    2019-10-01|      00:00:19|              10|            01|             00|                Tue|      view|   1005135|electronics.smart...|  electronics|   smartphone|         none|   apple|1747.79|\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+--------+-------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "par_df.orderBy(\"event_time\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -95,6 +156,8 @@
      "output_type": "stream",
      "text": [
       "root\n",
+      " |-- user_id: integer (nullable = true)\n",
+      " |-- user_session: string (nullable = true)\n",
       " |-- category_id: long (nullable = true)\n",
       " |-- event_time: timestamp (nullable = true)\n",
       " |-- event_time_ymd: date (nullable = true)\n",
@@ -111,8 +174,6 @@
       " |-- category_lv_3: string (nullable = true)\n",
       " |-- brand: string (nullable = true)\n",
       " |-- price: double (nullable = true)\n",
-      " |-- user_id: integer (nullable = true)\n",
-      " |-- user_session: string (nullable = true)\n",
       "\n"
      ]
     }
@@ -123,37 +184,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+-----+-----+---------+--------------------+\n",
-      "|        category_id|         event_time|event_time_ymd|event_time_hms|event_time_month|event_time_day|event_time_hour|event_time_day_name|event_type|product_id|       category_code|category_lv_1|category_lv_2|category_lv_3|brand|price|  user_id|        user_session|\n",
-      "+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+-----+-----+---------+--------------------+\n",
-      "|2053013552326770905|2019-10-01 09:00:00|    2019-10-01|      09:00:00|              10|            01|             00|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|554748717|9333dfbd-b87a-470...|\n",
-      "|2053013552326770905|2019-10-01 12:12:34|    2019-10-01|      12:12:34|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|512448158|52a857d6-b4db-42c...|\n",
-      "|2053013552326770905|2019-10-01 12:13:12|    2019-10-01|      12:13:12|              10|            01|             03|                Tue|  purchase|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|512448158|52a857d6-b4db-42c...|\n",
-      "|2053013552326770905|2019-10-01 12:24:58|    2019-10-01|      12:24:58|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|541410551|50b74e0f-83a4-411...|\n",
-      "|2053013552326770905|2019-10-01 12:27:28|    2019-10-01|      12:27:28|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|541410551|50b74e0f-83a4-411...|\n",
-      "|2053013552326770905|2019-10-01 12:27:48|    2019-10-01|      12:27:48|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|541410551|50b74e0f-83a4-411...|\n",
-      "|2053013552326770905|2019-10-01 12:30:35|    2019-10-01|      12:30:35|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|531153447|80ef3e67-93fc-435...|\n",
-      "|2053013552326770905|2019-10-01 12:30:52|    2019-10-01|      12:30:52|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|531153447|80ef3e67-93fc-435...|\n",
-      "|2053013552326770905|2019-10-01 12:32:16|    2019-10-01|      12:32:16|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|531153447|80ef3e67-93fc-435...|\n",
-      "|2053013552326770905|2019-10-01 12:32:56|    2019-10-01|      12:32:56|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|533907925|a896f11f-8b05-497...|\n",
-      "|2053013552326770905|2019-10-01 13:28:51|    2019-10-01|      13:28:51|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|543505965|c20a1e99-daa8-438...|\n",
-      "|2053013552326770905|2019-10-01 13:43:09|    2019-10-01|      13:43:09|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|536714737|b96744eb-57da-434...|\n",
-      "|2053013552326770905|2019-10-01 13:43:26|    2019-10-01|      13:43:26|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|536714737|b96744eb-57da-434...|\n",
-      "|2053013552326770905|2019-10-01 13:51:06|    2019-10-01|      13:51:06|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|512872339|bba8c738-3f6e-479...|\n",
-      "|2053013552326770905|2019-10-01 13:56:51|    2019-10-01|      13:56:51|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|515980327|cfa11b95-0725-48b...|\n",
-      "|2053013552326770905|2019-10-01 14:15:20|    2019-10-01|      14:15:20|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|512872339|bba8c738-3f6e-479...|\n",
-      "|2053013552326770905|2019-10-01 14:15:47|    2019-10-01|      14:15:47|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|512872339|bba8c738-3f6e-479...|\n",
-      "|2053013552326770905|2019-10-01 14:15:57|    2019-10-01|      14:15:57|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|512872339|bba8c738-3f6e-479...|\n",
-      "|2053013552326770905|2019-10-01 14:16:47|    2019-10-01|      14:16:47|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|542782262|c2213000-2725-445...|\n",
-      "|2053013552326770905|2019-10-01 14:17:10|    2019-10-01|      14:17:10|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|542782262|c2213000-2725-445...|\n",
-      "+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+-----+-----+---------+--------------------+\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+-----+-----+\n",
+      "|  user_id|        user_session|        category_id|         event_time|event_time_ymd|event_time_hms|event_time_month|event_time_day|event_time_hour|event_time_day_name|event_type|product_id|       category_code|category_lv_1|category_lv_2|category_lv_3|brand|price|\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+-----+-----+\n",
+      "|554748717|9333dfbd-b87a-470...|2053013552326770905|2019-10-01 09:00:00|    2019-10-01|      00:00:00|              10|            01|             00|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|512448158|52a857d6-b4db-42c...|2053013552326770905|2019-10-01 12:12:34|    2019-10-01|      03:12:34|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|512448158|52a857d6-b4db-42c...|2053013552326770905|2019-10-01 12:13:12|    2019-10-01|      03:13:12|              10|            01|             03|                Tue|  purchase|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|541410551|50b74e0f-83a4-411...|2053013552326770905|2019-10-01 12:24:58|    2019-10-01|      03:24:58|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|541410551|50b74e0f-83a4-411...|2053013552326770905|2019-10-01 12:27:28|    2019-10-01|      03:27:28|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|541410551|50b74e0f-83a4-411...|2053013552326770905|2019-10-01 12:27:48|    2019-10-01|      03:27:48|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|531153447|80ef3e67-93fc-435...|2053013552326770905|2019-10-01 12:30:35|    2019-10-01|      03:30:35|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|531153447|80ef3e67-93fc-435...|2053013552326770905|2019-10-01 12:30:52|    2019-10-01|      03:30:52|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|531153447|80ef3e67-93fc-435...|2053013552326770905|2019-10-01 12:32:16|    2019-10-01|      03:32:16|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|533907925|a896f11f-8b05-497...|2053013552326770905|2019-10-01 12:32:56|    2019-10-01|      03:32:56|              10|            01|             03|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|543505965|c20a1e99-daa8-438...|2053013552326770905|2019-10-01 13:28:51|    2019-10-01|      04:28:51|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|536714737|b96744eb-57da-434...|2053013552326770905|2019-10-01 13:43:09|    2019-10-01|      04:43:09|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|536714737|b96744eb-57da-434...|2053013552326770905|2019-10-01 13:43:26|    2019-10-01|      04:43:26|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|512872339|bba8c738-3f6e-479...|2053013552326770905|2019-10-01 13:51:06|    2019-10-01|      04:51:06|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|515980327|cfa11b95-0725-48b...|2053013552326770905|2019-10-01 13:56:51|    2019-10-01|      04:56:51|              10|            01|             04|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|512872339|bba8c738-3f6e-479...|2053013552326770905|2019-10-01 14:15:20|    2019-10-01|      05:15:20|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|512872339|bba8c738-3f6e-479...|2053013552326770905|2019-10-01 14:15:47|    2019-10-01|      05:15:47|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|512872339|bba8c738-3f6e-479...|2053013552326770905|2019-10-01 14:15:57|    2019-10-01|      05:15:57|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|542782262|c2213000-2725-445...|2053013552326770905|2019-10-01 14:16:47|    2019-10-01|      05:16:47|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "|542782262|c2213000-2725-445...|2053013552326770905|2019-10-01 14:17:10|    2019-10-01|      05:17:10|              10|            01|             05|                Tue|      view|   3900821|appliances.enviro...|   appliances|  environment| water_heater| aqua| 33.2|\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+-----+-----+\n",
       "only showing top 20 rows\n",
       "\n"
      ]
@@ -165,6 +226,48 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+--------+-------+\n",
+      "|  user_id|        user_session|        category_id|         event_time|event_time_ymd|event_time_hms|event_time_month|event_time_day|event_time_hour|event_time_day_name|event_type|product_id|       category_code|category_lv_1|category_lv_2|category_lv_3|   brand|  price|\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+--------+-------+\n",
+      "|537280720|390dfca9-0882-49b...|2053013560807654091|2019-10-08 00:00:00|    2019-10-08|      00:00:00|              10|            08|             00|                Tue|      view|   6000094|auto.accessories....|         auto|  accessories|        alarm|starline| 121.24|\n",
+      "|548175652|7a0c755d-425b-4fb...|2053013555631882655|2019-10-08 00:00:00|    2019-10-08|      00:00:00|              10|            08|             00|                Tue|      view|   1004659|electronics.smart...|  electronics|   smartphone|         none| samsung| 731.04|\n",
+      "|557874027|ddcb6b28-70ce-4e0...|2053013553945772349|2019-10-08 00:00:01|    2019-10-08|      00:00:01|              10|            08|             00|                Tue|      view|   5800572|electronics.audio...|  electronics|        audio|    subwoofer| pioneer|  27.03|\n",
+      "|523342162|188a14b5-1401-428...|2053013553559896355|2019-10-08 00:00:01|    2019-10-08|      00:00:01|              10|            08|             00|                Tue|      view|  12711986|             unknown|      unknown|         none|         none|triangle|  37.32|\n",
+      "|535953168|521339a7-ef97-4de...|2053013554189041997|2019-10-08 00:00:02|    2019-10-08|      00:00:02|              10|            08|             00|                Tue|      view|   6601051|computers.compone...|    computers|   components|       memory|kingston| 149.13|\n",
+      "|553172747|2b927880-1a4f-4e5...|2053013562250494749|2019-10-08 00:00:02|    2019-10-08|      00:00:02|              10|            08|             00|                Tue|      view|  25510249|             unknown|      unknown|         none|         none|   gerat|  25.48|\n",
+      "|551456693|9ac092d2-d4d9-403...|2053013553970938175|2019-10-08 00:00:02|    2019-10-08|      00:00:02|              10|            08|             00|                Tue|      view|   5701020|auto.accessories....|         auto|  accessories|       player| pioneer|  23.14|\n",
+      "|557618636|f42efcd3-20c4-427...|2053013558920217191|2019-10-08 00:00:03|    2019-10-08|      00:00:03|              10|            08|             00|                Tue|      view|   1307429|  computers.notebook|    computers|     notebook|         none|    asus| 483.67|\n",
+      "|557874344|3a449ac1-8320-4b4...|2053013564003713919|2019-10-08 00:00:04|    2019-10-08|      00:00:04|              10|            08|             00|                Tue|      view|   2500566|appliances.kitche...|   appliances|      kitchen|         oven|    asel|  43.73|\n",
+      "|527086940|034749c7-77ab-44e...|2053013562913194819|2019-10-08 00:00:06|    2019-10-08|      00:00:06|              10|            08|             00|                Tue|      view|   5600400|             unknown|      unknown|         none|         none| philips|  43.73|\n",
+      "|557874370|f5d29b25-9723-42b...|2053013555631882655|2019-10-08 00:00:06|    2019-10-08|      00:00:06|              10|            08|             00|                Tue|  purchase|   1004210|electronics.smart...|  electronics|   smartphone|         none| samsung|  88.81|\n",
+      "|553172747|2b927880-1a4f-4e5...|2053013562250494749|2019-10-08 00:00:07|    2019-10-08|      00:00:07|              10|            08|             00|                Tue|      view|  25510090|             unknown|      unknown|         none|         none|   gerat|  80.05|\n",
+      "|557618636|f42efcd3-20c4-427...|2053013558920217191|2019-10-08 00:00:07|    2019-10-08|      00:00:07|              10|            08|             00|                Tue|      view|   1305864|  computers.notebook|    computers|     notebook|         none|  lenovo| 499.11|\n",
+      "|550334112|9a84f334-4d12-477...|2053013563584283495|2019-10-08 00:00:07|    2019-10-08|      00:00:07|              10|            08|             00|                Tue|      view|  26300032|             unknown|      unknown|         none|         none| lucente|  123.3|\n",
+      "|539050258|f144c3ef-ff8f-42a...|2053013555631882655|2019-10-08 00:00:07|    2019-10-08|      00:00:07|              10|            08|             00|                Tue|      view|   1004856|electronics.smart...|  electronics|   smartphone|         none| samsung| 130.76|\n",
+      "|535953168|521339a7-ef97-4de...|2053013554189041997|2019-10-08 00:00:08|    2019-10-08|      00:00:08|              10|            08|             00|                Tue|      view|   6601045|computers.compone...|    computers|   components|       memory|kingston| 101.16|\n",
+      "|547705718|20b0474e-8dae-41a...|2053013558316237377|2019-10-08 00:00:08|    2019-10-08|      00:00:08|              10|            08|             00|                Tue|      view|  16800045|furniture.kitchen...|    furniture|      kitchen|        table|     bts| 185.31|\n",
+      "|513671262|24a2f780-d5c9-451...|2053013555631882655|2019-10-08 00:00:09|    2019-10-08|      00:00:09|              10|            08|             00|                Tue|      view|   1004843|electronics.smart...|  electronics|   smartphone|         none|   meizu| 231.41|\n",
+      "|518698290|87de04de-3962-4e4...|2059484601444729123|2019-10-08 00:00:09|    2019-10-08|      00:00:09|              10|            08|             00|                Tue|      view|  29900055|             unknown|      unknown|         none|         none|    peda|2331.85|\n",
+      "|529045018|a3806158-4825-4df...|2053013556168753601|2019-10-08 00:00:10|    2019-10-08|      00:00:10|              10|            08|             00|                Tue|      view|  22700044|             unknown|      unknown|         none|         none|   total|  43.73|\n",
+      "+---------+--------------------+-------------------+-------------------+--------------+--------------+----------------+--------------+---------------+-------------------+----------+----------+--------------------+-------------+-------------+-------------+--------+-------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "par_08_df.orderBy(\"event_time\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -172,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -198,6 +301,285 @@
     "\n",
     "parquet_df = spark.read.parquet(os.path.join(output_folder, \"total_merged.parquet\"))\n",
     "parquet_df.show(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oct_df = spark.read.parquet(os.path.join(output_folder, \"2019_oct.parquet\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|event_time|event_type|product_id|category_id|category_code|  brand|price|user_id|user_session|event_time_ymd|event_time_hms|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|         0|         0|         0|          0|     13515609|6113008|    0|      0|           2|             0|             0|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "null_counts = oct_df.agg(\n",
+    "    *[sum(col(c).isNull().cast(\"int\")).alias(c) for c in oct_df.columns]\n",
+    ")\n",
+    "null_counts.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def impute_by_mode_value(df, group_col, target_col):\n",
+    "    \"\"\"\n",
+    "    특정 그룹(group_col) 내에서 target_col의 최빈값을 찾아 NULL 값을 대체하는 함수.\n",
+    "\n",
+    "    df: 입력 Spark DataFrame\n",
+    "    group_col: 그룹화할 컬럼명 (예: category_id)\n",
+    "    target_col: 최빈값을 찾고 NULL을 채울 컬럼명 (예: category_code)\n",
+    "    return: NULL 값이 최빈값으로 채워진 DataFrame\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # 1️. group_col별 target_col에서 최빈값 찾기\n",
+    "    value_counts = (\n",
+    "        df\n",
+    "        .groupBy(group_col, target_col)\n",
+    "        .agg(count(\"*\").alias(\"count\"))  # count 횟수 계산\n",
+    "    )\n",
+    "\n",
+    "    # 2️. 최빈값을 찾기 위한 Window 함수 설정\n",
+    "    window_spec = Window.partitionBy(group_col).orderBy(col(\"count\").desc(), col(target_col))\n",
+    "\n",
+    "    most_frequent_values = (\n",
+    "        value_counts\n",
+    "        .withColumn(\"rank\", row_number().over(window_spec))  # 최빈값 순위 매기기\n",
+    "        .filter(col(\"rank\") == 1)  # 최빈값 선택\n",
+    "        .select(col(group_col), col(target_col).alias(f\"most_frequent_{target_col}\"))\n",
+    "    )\n",
+    "\n",
+    "    # 3️. 기존 데이터와 조인 후 NULL 값 채우기\n",
+    "    df = (\n",
+    "        df\n",
+    "        .join(most_frequent_values, on=group_col, how=\"left\")  # group_col 기준으로 병합\n",
+    "        .withColumn(target_col, coalesce(col(target_col), col(f\"most_frequent_{target_col}\")))\n",
+    "        .drop(f\"most_frequent_{target_col}\") \n",
+    "    )\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oct_df_2 = impute_by_mode_value(oct_df, \"product_id\", \"brand\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|product_id|event_time|event_type|category_id|category_code|  brand|price|user_id|user_session|event_time_ymd|event_time_hms|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|         0|         0|         0|          0|     13515609|6038239|    0|      0|           2|             0|             0|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "# 결측치 개수 확인\n",
+    "oct_df_2.select([count(when(col(c).isNull(), c)).alias(c) for c in oct_df_2.columns]).show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.window import Window\n",
+    "from pyspark.sql import DataFrame\n",
+    "\n",
+    "def impute_by_mode_value(df: DataFrame, group_col: str, target_col: str) -> DataFrame:\n",
+    "    \"\"\"\n",
+    "    특정 그룹(group_col) 내에서 target_col의 최빈값(mode)을 찾아 NULL 값을 대체하는 함수입니다.\n",
+    "    이 함수는 리소스 사용 최적화를 위해 필요한 컬럼만 선택하고, 계산된 최빈값 결과를 브로드캐스트 조인으로 사용합니다.\n",
+    "    \n",
+    "    Parameters:\n",
+    "    - df: 입력 Spark DataFrame\n",
+    "    - group_col: 그룹화할 컬럼명 (예: category_id)\n",
+    "    - target_col: 최빈값을 찾아 NULL을 채울 컬럼명 (예: category_code)\n",
+    "    \n",
+    "    return: target_col의 NULL 값이 해당 그룹의 non-null 최빈값으로 채워진 DataFrame\n",
+    "    \"\"\"\n",
+    "    # 1. 필요한 컬럼만 선택 (group_col, target_col)\n",
+    "    df_reduced = df.select(group_col, target_col)\n",
+    "    \n",
+    "    # 2. non-null인 target_col만 고려하여 집계\n",
+    "    non_null_df = df_reduced.filter(F.col(target_col).isNotNull())\n",
+    "    \n",
+    "    # 3. 그룹별로 target_col 값의 count 계산\n",
+    "    value_counts = (\n",
+    "        non_null_df\n",
+    "        .groupBy(group_col, target_col)\n",
+    "        .agg(F.count(\"*\").alias(\"count\"))\n",
+    "    )\n",
+    "    \n",
+    "    # 4. Window 함수를 이용해 그룹별로 count 내림차순 정렬 후 최빈값 선택\n",
+    "    window_spec = Window.partitionBy(group_col).orderBy(F.col(\"count\").desc(), F.col(target_col))\n",
+    "    \n",
+    "    mode_df = (\n",
+    "        value_counts\n",
+    "        .withColumn(\"rank\", F.row_number().over(window_spec))\n",
+    "        .filter(F.col(\"rank\") == 1)\n",
+    "        .select(group_col, F.col(target_col).alias(f\"most_frequent_{target_col}\"))\n",
+    "    )\n",
+    "    \n",
+    "    # 5. mode_df를 브로드캐스트하여 조인 성능 향상\n",
+    "    mode_df = F.broadcast(mode_df)\n",
+    "    \n",
+    "    # 6. 원본 데이터와 조인한 후, target_col이 NULL인 경우에만 최빈값으로 대체\n",
+    "    df_imputed = (\n",
+    "        df\n",
+    "        .join(mode_df, on=group_col, how=\"left\")\n",
+    "        .withColumn(target_col, F.coalesce(F.col(target_col), F.col(f\"most_frequent_{target_col}\")))\n",
+    "        .drop(f\"most_frequent_{target_col}\")\n",
+    "    )\n",
+    "    \n",
+    "    return df_imputed\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oct_df_3 = impute_by_mode_value(oct_df, \"product_id\", \"brand\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|product_id|event_time|event_type|category_id|category_code|  brand|price|user_id|user_session|event_time_ymd|event_time_hms|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|         0|         0|         0|          0|     13515609|5940585|    0|      0|           2|             0|             0|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "# 결측치 개수 확인\n",
+    "oct_df_3.select([count(when(col(c).isNull(), c)).alias(c) for c in oct_df_3.columns]).show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42448764"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct_df.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42448764"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oct_df_3.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oct_df_4 = impute_by_mode_value(oct_df, \"category_id\", \"category_code\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+----------+----------+----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|category_id|event_time|event_type|product_id|category_code|  brand|price|user_id|user_session|event_time_ymd|event_time_hms|\n",
+      "+-----------+----------+----------+----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|          0|         0|         0|         0|     13515609|6113008|    0|      0|           2|             0|             0|\n",
+      "+-----------+----------+----------+----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "# 결측치 개수 확인\n",
+    "oct_df_4.select([count(when(col(c).isNull(), c)).alias(c) for c in oct_df_4.columns]).show()\n"
    ]
   },
   {
@@ -1177,6 +1559,117 @@
    "source": [
     "null_counts_cc_filled = parquet_filled_cc.select(\n",
     "    [F.count(F.when(F.col(c).isNull(), c)).alias(c) for c in parquet_filled.columns]\n",
+    ")\n",
+    "null_counts_cc_filled.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 이 밑으로는 지우기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1. category_id별로 NULL이 아닌 첫 번째 category_code 값을 가져오기\n",
+    "filled_category_codes = (\n",
+    "    oct_df\n",
+    "    .filter(col(\"category_code\").isNotNull())  # NULL이 아닌 값만 사용\n",
+    "    .groupBy(\"category_id\")\n",
+    "    .agg(first(\"category_code\").alias(\"filled_category_code\"))  # 첫 번째 category_code 값 추출\n",
+    ")\n",
+    "\n",
+    "# 2️. 기존 데이터와 조인 후, NULL 값 채우기\n",
+    "parquet_filled_oct = (\n",
+    "    oct_df\n",
+    "    .join(filled_category_codes, on=\"category_id\", how=\"left\")  # 동일한 category_id를 기준으로 병합\n",
+    "    .withColumn(\"category_code\", coalesce(col(\"category_code\"), col(\"filled_category_code\")))  # NULL이면 대체\n",
+    "    .drop(\"filled_category_code\")  # 불필요한 컬럼 제거\n",
+    ")\n",
+    "\n",
+    "# 3️. 결과 확인\n",
+    "# parquet_filled_oct.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+----------+----------+----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|category_id|event_time|event_type|product_id|category_code|  brand|price|user_id|user_session|event_time_ymd|event_time_hms|\n",
+      "+-----------+----------+----------+----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|          0|         0|         0|         0|     13515609|6113008|    0|      0|           2|             0|             0|\n",
+      "+-----------+----------+----------+----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "null_counts_cc_filled = parquet_filled_oct.select(\n",
+    "    [F.count(F.when(F.col(c).isNull(), c)).alias(c) for c in parquet_filled_oct.columns]\n",
+    ")\n",
+    "null_counts_cc_filled.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1. product_id별로 NULL이 아닌 첫 번째 category_code 값을 가져오기\n",
+    "filled_category_codes = (\n",
+    "    oct_df\n",
+    "    .filter(col(\"category_code\").isNotNull())  # NULL이 아닌 값만 사용\n",
+    "    .groupBy(\"product_id\")\n",
+    "    .agg(first(\"category_code\").alias(\"filled_category_code\"))  # 첫 번째 category_code 값 추출\n",
+    ")\n",
+    "\n",
+    "# 2️. 기존 데이터와 조인 후, NULL 값 채우기\n",
+    "parquet_filled_oct = (\n",
+    "    oct_df\n",
+    "    .join(filled_category_codes, on=\"product_id\", how=\"left\")  # 동일한 product_id를 기준으로 병합\n",
+    "    .withColumn(\"category_code\", coalesce(col(\"category_code\"), col(\"filled_category_code\")))  # NULL이면 대체\n",
+    "    .drop(\"filled_category_code\")  # 불필요한 컬럼 제거\n",
+    ")\n",
+    "\n",
+    "# 3️. 결과 확인\n",
+    "# parquet_filled_oct.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|product_id|event_time|event_type|category_id|category_code|  brand|price|user_id|user_session|event_time_ymd|event_time_hms|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "|         0|         0|         0|          0|     13515609|6113008|    0|      0|           2|             0|             0|\n",
+      "+----------+----------+----------+-----------+-------------+-------+-----+-------+------------+--------------+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "null_counts_cc_filled = parquet_filled_oct.select(\n",
+    "    [F.count(F.when(F.col(c).isNull(), c)).alias(c) for c in parquet_filled_oct.columns]\n",
     ")\n",
     "null_counts_cc_filled.show()"
    ]

--- a/spark/conf/spark-env.sh
+++ b/spark/conf/spark-env.sh
@@ -28,3 +28,7 @@ LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
 LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
 LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
 LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
+LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
+LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
+LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so
+LD_PRELOAD=/opt/bitnami/common/lib/libnss_wrapper.so


### PR DESCRIPTION
- s3/processed-data에 적재되는 Transform 작업의 순서를 변경했습니다.
    - 기존 작업 - category_code, event_time 컬럼 분리 → 결측치 처리 수행 - 대체되지 않은 결측치는 제거 (`dropna`)
    - 변경된 작업
        - 결측치 처리 → category_code, event_time 컬럼 분리
        - 대체되지 않은 결측치는 `unknown`으로 변경
- 기존 작업과의 비교
    - 기존 작업: raw category_code를 먼저 분리 → 나뉘어진 category_lv_1, category_lv_2, category_lv_3에 결측치 대체 작업이 반영되지 않음
    - 변경된 작업: category_code의 결측치를 먼저 대체 → category_lv_1, category_lv_2, category_lv_3에 대체된 값 반영